### PR TITLE
expands the project by a package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "invade",
+  "version": "0.0.1",
+  "description": "A command-line interface for the multiparty music-player 'screeninvader'",
+  "author": "Burnoutberni <hello@nini.su>",
+  "contributors": [{
+    "name": "Burnoutberni",
+    "email": "hello@nini.su"
+  }],
+  "bin": {
+    "invade": "./invade.js"
+  },
+  "main": "./invade.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/burnoutberni/screeninvader-cli"
+  },
+  "bugs": {
+    "url": "https://github.com/burnoutberni/screeninvader-cli/issues"
+  },
+  "keywords": [
+    "screeninvader",
+    "mplayer",
+    "cli"
+  ],
+  "dependencies": {
+    "commander": "2.7.1",
+    "valid-url": "1.0.9",
+    "promptly": "0.2.1"
+  },
+  "preferGlobal": true,
+  "analyze": true,
+  "license": "GPLv2"
+}


### PR DESCRIPTION
You can now install the dependencies by `npm install -g´.
This closes #1.
